### PR TITLE
Minor fix: vim.fn.isdirectory and vim.fn.mkdir

### DIFF
--- a/lua/conceal/init.lua
+++ b/lua/conceal/init.lua
@@ -37,7 +37,7 @@ end
 ---@param content table the generated querries
 local write_to_file = function(language, content)
     local dir = vim.fn.stdpath("config") .. "/after/queries/" .. language
-    if not vim.fn.isdirectory(dir) then vim.fn.mkdir(dir, "p", 0o755) end
+    if vim.fn.isdirectory(dir) == 0 then vim.fn.mkdir(dir, "p", "0755") end
     local file_path = dir .. "/highlights.scm"
     local file = io.open(file_path, "w+")
     if file ~= nil then


### PR DESCRIPTION
1. since the only "falsey" values in lua are `nil` and `false`, you can't do `if vim.fn.isdirectory(dir) then`, as it returns a number. you must instead explicitly check the return value e.g. `if vim.fn.isdirectory(dir) == 0 then`. (i was seeing that `:lua require'conceal'.generate_conceals()` was failing to make any `after/queries` directories as expected. once the directories exist, this line has no effect either way.)
2. octal values `0o755` result in a "malformed number" in lua, although they are valid in vimscript. not sure how they worked on your side, maybe some difference in lua version? this commit changes the number to a string (or you could omit it entirely, as docs indicate 755 is the default value)

----

```
NVIM v0.9.0-dev-124-gbd7ca10fd
Build type: RelWithDebInfo
LuaJIT 2.1.0-beta3
Compilation: /Library/Developer/CommandLineTools/usr/bin/cc -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1 -DNVIM_TS_HAS_SET_MATCH_LIMIT -DNVIM_TS_HAS_SET_ALLOCATOR -O2 -g -Wall -Wextra -pedantic -Wno-unused-parameter -Wstrict-prototypes -std=gnu99 -Wshadow -Wconversion -Wdouble-promotion -Wmissing-noreturn -Wmissing-format-attribute -Wmissing-prototypes -Wimplicit-fallthrough -Wvla -fstack-protector-strong -fno-common -fdiagnostics-color=always -DINCLUDE_GENERATED_DECLARATIONS -DNVIM_MSGPACK_HAS_FLOAT32 -DNVIM_UNIBI_HAS_VAR_FROM -DMIN_LOG_LEVEL=3 -I/Users/amar/.local/share/bob/neovim-git/build/cmake.config -I/Users/amar/.local/share/bob/neovim-git/src -I/Users/amar/.local/share/bob/neovim-git/.deps/usr/include -I/Library/Developer/CommandLineTools/SDKs/MacOSX13.0.sdk/usr/include -I/opt/homebrew/opt/gettext/include -I/Users/amar/.local/share/bob/neovim-git/build/src/nvim/auto -I/Users/amar/.local/share/bob/neovim-git/build/include
Compiled by amar@FVFGH2DDQ05P-ML

Features: +acl +iconv +tui
See ":help feature-compile"

   system vimrc file: "$VIM/sysinit.vim"
  fall-back for $VIM: "
/Users/amar/.local/share/bob/bd7ca10/nvim-macos/share/nvim"

Run :checkhealth for more info
```