### PR TITLE
add language support for python

### DIFF
--- a/lua/conceal/config.lua
+++ b/lua/conceal/config.lua
@@ -1,3 +1,5 @@
+local language_defaults = require("conceal.language_defaults")
+
 return {
     --[[ ["language"] = {
         enabled = bool,
@@ -92,5 +94,10 @@ return {
                 highlight = "keyword"
             }
         }
-    }
+    },
+
+    ["python"] = {
+        enabled = true,
+        keywords = language_defaults.python,
+    },
 }

--- a/lua/conceal/language_defaults/init.lua
+++ b/lua/conceal/language_defaults/init.lua
@@ -1,0 +1,5 @@
+local language_defaults = {}
+
+language_defaults["python"] = require("conceal.language_defaults.python")
+
+return language_defaults

--- a/lua/conceal/language_defaults/python.lua
+++ b/lua/conceal/language_defaults/python.lua
@@ -1,0 +1,124 @@
+return {
+    ["import"] = {
+        enabled = true,
+        conceal = "i",
+        highlight = "include"
+    },
+    ["def"] = {
+        enabled = true,
+        conceal = "f",
+        highlight = "keyword.function"
+    },
+    ["class"] = {
+        enabled = true,
+        conceal = "c",
+        highlight = "keyword"
+    },
+    ["global"] = {
+        enabled = true,
+        conceal = "G",
+        highlight = "keyword"
+    },
+    ["del"] = {
+        enabled = true,
+        conceal = "D",
+        highlight = "keyword"
+    },
+    ["if"] = {
+        enabled = true,
+        conceal = "?",
+        highlight = "conditional"
+    },
+    ["else"] = {
+        enabled = true,
+        conceal = "e",
+        highlight = "conditional"
+    },
+    ["elif"] = {
+        enabled = true,
+        conceal = "e",
+        highlight = "conditional"
+    },
+    ["pass"] = {
+        enabled = true,
+        conceal = "P",
+        highlight = "keyword"
+    },
+    ["break"] = {
+        enabled = true,
+        conceal = "B",
+        highlight = "keyword"
+    },
+    ["continue"] = {
+        enabled = true,
+        conceal = "R",
+        highlight = "keyword"
+    },
+    ["return"] = {
+        enabled = true,
+        conceal = "R",
+        highlight = "keyword"
+    },
+    ["yield"] = {
+        enabled = true,
+        conceal = "Y",
+        highlight = "keyword"
+    },
+    ["for"] = {
+        enabled = true,
+        conceal = "F",
+        highlight = "repeat"
+    },
+    ["while"] = {
+        enabled = true,
+        conceal = "W",
+        highlight = "repeat"
+    },
+    ["with"] = {
+        enabled = true,
+        conceal = "w",
+        highlight = "keyword"
+    },
+    ["lambda"] = {
+        enabled = true,
+        conceal = "λ",
+        highlight = "include"
+    },
+    ["assert"] = {
+        enabled = true,
+        -- same symbol as "if", but context is different:
+        -- no trailing ':', won't be used in ternary statements.
+        conceal = "?",
+        highlight = "keyword"
+    },
+    ["and"] = {
+        enabled = true,
+        conceal = "&",
+        highlight = "keyword.operator"
+    },
+    ["or"] = {
+        enabled = true,
+        conceal = "|",
+        highlight = "keyword.operator"
+    },
+    ["not"] = {
+        enabled = true,
+        conceal = "!",
+        highlight = "keyword.operator"
+    },
+    ["from_import"] = {
+        enabled = true,
+        conceal = "f",
+        highlight = "include"
+    },
+    ["from_yield"] = {
+        enabled = true,
+        conceal = "F",
+        highlight = "keyword"
+    },
+    ["print"] = {
+        enabled = true,
+        conceal = "p",
+        highlight = "function.builtin"
+    },
+}

--- a/lua/conceal/templates/python.lua
+++ b/lua/conceal/templates/python.lua
@@ -1,0 +1,56 @@
+local utils = require("conceal.templates.utils")
+
+-- Don't conceal:
+-- as
+-- in
+-- is
+-- nonlocal
+-- try/except/finally/raise
+-- async/await
+
+-- some keywords have multiple contexts:
+-- from * import *      vs yield from   (handled below)
+-- if/else vs for/else  vs try/else     (else always goes to same token)
+-- import * as          vs with * as    (as is not concealed)
+
+local keywords = {}
+for _, keyword in ipairs({
+    "import",
+    "def",
+    "class",
+    "global",
+    "del",
+    "if",
+    "else",
+    "elif",
+    "pass",
+    "break",
+    "continue",
+    "return",
+    "yield",
+    "for",
+    "while",
+    "with",
+    "lambda",
+    "assert",
+    "and",
+    "or",
+    "not",
+}) do
+    keywords[keyword] = utils.query_builder(keyword)
+end
+
+-- `from` has two valid meanings: part of from import or part of yield from
+keywords["from_import"] = function(options)
+    return string.format('((import_from_statement ("from") @%s) (#set! conceal "%s"))', options.highlight, options.conceal)
+end
+keywords["from_yield"] = function(options)
+    return string.format('((yield ("from") @%s) (#set! conceal "%s"))', options.highlight, options.conceal)
+end
+
+-- some syntax sugar for common builtins
+keywords["print"] = function(options)
+    return string.format('((call function: (identifier) @%s (#eq? @%s "print")) (#set! conceal "%s"))', options.highlight, options.highlight, options.conceal)
+end
+
+return keywords

--- a/lua/conceal/templates/utils.lua
+++ b/lua/conceal/templates/utils.lua
@@ -1,0 +1,10 @@
+-- most common use case is replacing an explicit keyword (e.g. "return") with the value of options.conceal
+local query_builder = function(text)
+    return function(options)
+        return string.format('(("%s" @%s) (#set! conceal "%s"))', text, options.highlight, options.conceal)
+    end
+end
+
+return {
+    query_builder = query_builder,
+}


### PR DESCRIPTION
This is a really neat plugin, thanks for publishing it!

I added support for python here. I'm not very familiar with lua yet, but I tried to write this in a way to make it easier to extend for other languages as well - so i made a helper function in the `conceal.templates.utils` for common queries, as well as a new `language_defaults` submodule to try to keep the `config.lua` a bit cleaner if you add more languages later.

Let me know if you'd like anything changed.