### PR TITLE
typo: change conceal for "continue" to "C"

### DIFF
--- a/lua/conceal/language_defaults/python.lua
+++ b/lua/conceal/language_defaults/python.lua
@@ -51,7 +51,7 @@ return {
     },
     ["continue"] = {
         enabled = true,
-        conceal = "R",
+        conceal = "C",
         highlight = "keyword"
     },
     ["return"] = {


### PR DESCRIPTION
my bad, must have missed this `"R"` when making the initial config